### PR TITLE
fix: validate Score files locally when there is no org set

### DIFF
--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -16,7 +16,7 @@ export default defineConfig([
       timeout: 20000,
       asyncOnly: true,
     },
-    launchArgs: [`--user-data-dir=${userDir}`],
+    launchArgs: [`--user-data-dir=${userDir}`, '--disable-extensions'],
   },
   // you can specify additional test configurations, too
 ]);

--- a/src/controllers/HumanitecSidebarController.ts
+++ b/src/controllers/HumanitecSidebarController.ts
@@ -144,6 +144,7 @@ export class HumanitecSidebarController {
                 item.id
               );
             }
+            vscode.commands.executeCommand('humanitec.score.validate');
           } else if (item instanceof Application) {
             await configurationRepository.set(ConfigKey.HUMANITEC_ENV, '');
             const orgId = await configurationRepository.get(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,7 +24,7 @@ export const loggerChannel = vscode.window.createOutputChannel('Humanitec');
 export async function activate(context: vscode.ExtensionContext) {
   const logger = new LoggerService(loggerChannel);
   const configurationRepository = new ConfigurationRepository();
-  const secretRepository = new SecretRepository(context.secrets, logger);
+  const secretRepository = new SecretRepository();
   const humctl = new HumctlAdapter(
     configurationRepository,
     secretRepository,
@@ -52,6 +52,7 @@ export async function activate(context: vscode.ExtensionContext) {
   ValidateScoreFileController.register(
     context,
     new ScoreValidationService(humctl),
+    configurationRepository,
     logger
   );
   InitializeScoreFileController.register(

--- a/src/repos/SecretRepository.ts
+++ b/src/repos/SecretRepository.ts
@@ -1,10 +1,8 @@
-import * as vscode from 'vscode';
 import { SecretKey } from '../domain/SecretKey';
 import { homedir } from 'os';
 import path from 'path';
 import { readFileSync, writeFileSync } from 'fs';
 import { parse, stringify } from 'yaml';
-import { ILoggerService } from '../services/LoggerService';
 
 export interface ISecretRepository {
   get(key: SecretKey): Promise<string>;
@@ -12,10 +10,7 @@ export interface ISecretRepository {
 }
 
 export class SecretRepository implements ISecretRepository {
-  constructor(
-    private secrets: vscode.SecretStorage,
-    private logger: ILoggerService
-  ) {}
+  constructor() {}
 
   async set(key: SecretKey, value: string): Promise<void> {
     const configPath = path.join(homedir(), '.humctl');

--- a/src/services/ScoreValidationService.ts
+++ b/src/services/ScoreValidationService.ts
@@ -1,7 +1,7 @@
 import { IHumctlAdapter } from '../adapters/humctl/IHumctlAdapter';
 
 export interface IScoreValidationService {
-  validate(filepath: string): Promise<ValidationError[]>;
+  validate(filepath: string, onlyLocal: boolean): Promise<ValidationError[]>;
 }
 
 export class ValidationError {
@@ -25,8 +25,17 @@ interface RawValidationError {
 export class ScoreValidationService implements IScoreValidationService {
   constructor(private humctl: IHumctlAdapter) {}
 
-  async validate(filepath: string): Promise<ValidationError[]> {
-    const result = await this.humctl.execute(['score', 'validate', filepath]);
+  async validate(
+    filepath: string,
+    onlyLocal: boolean
+  ): Promise<ValidationError[]> {
+    const command = ['score', 'validate'];
+    if (onlyLocal) {
+      command.push('--local');
+    }
+    command.push(filepath);
+
+    const result = await this.humctl.execute(command);
 
     const validationErrors: ValidationError[] = [];
     // TODO: Make the handling better

--- a/src/test/suite/validate_score_file.test.ts
+++ b/src/test/suite/validate_score_file.test.ts
@@ -1,0 +1,155 @@
+import * as vscode from 'vscode';
+import { suite, beforeEach, before, afterEach, test } from 'mocha';
+import sinon from 'sinon';
+import path from 'path';
+import waitForExpect from 'wait-for-expect';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import { readEnv } from '../utils';
+
+const expect = chai.expect;
+chai.use(sinonChai);
+
+suite('When validate score file command triggered', () => {
+  const statusBarItemShow = sinon.spy();
+  const statusBarItemHide = sinon.spy();
+  const humanitecOrg = readEnv('TEST_HUMANITEC_ORG');
+  const humanitecToken = readEnv('TEST_HUMANITEC_TOKEN');
+
+  let sandbox: sinon.SinonSandbox;
+  let statusBarItem: vscode.StatusBarItem;
+  let workspaceFolder: string;
+  let doc: vscode.TextDocument;
+  let errorMessageShow: sinon.SinonStub;
+
+  const createFakeStatusBarItem = () => {
+    const fakeItem = {
+      id: 'id',
+      alignment: vscode.StatusBarAlignment.Right,
+      priority: undefined,
+      name: undefined,
+      text: 'text',
+      tooltip: undefined,
+      color: undefined,
+      backgroundColor: undefined,
+      command: undefined,
+      accessibilityInformation: undefined,
+      show: statusBarItemShow,
+      hide: statusBarItemHide,
+      dispose: sinon.spy(),
+    };
+    statusBarItem = fakeItem;
+    return fakeItem;
+  };
+
+  before(async () => {
+    if (!vscode.workspace.workspaceFolders) {
+      throw new Error('Workspace folder not found');
+    }
+    workspaceFolder = vscode.workspace.workspaceFolders[0].uri.path;
+
+    const ext = vscode.extensions.getExtension('humanitec.humanitec');
+    if (!ext) {
+      throw new Error('Extension not found');
+    }
+    await ext.activate();
+
+    doc = await vscode.workspace.openTextDocument(
+      path.join(workspaceFolder, './score.yaml')
+    );
+    //await vscode.window.showTextDocument(doc);
+  });
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    sandbox
+      .stub(vscode.window, 'createStatusBarItem')
+      .callsFake(createFakeStatusBarItem);
+    errorMessageShow = sandbox
+      .stub(vscode.window, 'showErrorMessage')
+      .callsFake(
+        (message, ...items): Thenable<vscode.MessageItem | undefined> => {
+          console.log('showErrorMessage', message, ...items);
+          return Promise.resolve(undefined);
+        }
+      );
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  test('given user is not logged, should validate the Score files locally', async () => {
+    sandbox.stub(vscode.window, 'showInputBox').resolves('');
+    await vscode.commands.executeCommand('humanitec.set_token');
+
+    await vscode.workspace
+      .getConfiguration('humanitec')
+      .update('organization', '');
+
+    await vscode.commands.executeCommand('humanitec.score.validate');
+
+    await waitForExpect(() => {
+      const diagnostics = vscode.languages.getDiagnostics(doc.uri);
+      expect(diagnostics).not.to.be.empty;
+      expect(statusBarItemShow).to.have.been.called;
+      expect(statusBarItem.text).to.be.eq('$(warning) Only local validation');
+      expect(statusBarItem.tooltip).to.be.eq(
+        'There is no organization set so Humanitec Extension could only validate the Score files locally'
+      );
+    });
+  });
+
+  test('given user is logged, but workspace has no organization in use, should validate the Score files locally', async () => {
+    sandbox.stub(vscode.window, 'showInputBox').resolves(humanitecToken);
+    await vscode.commands.executeCommand('humanitec.set_token');
+
+    await vscode.workspace
+      .getConfiguration('humanitec')
+      .update('organization', '');
+
+    await vscode.commands.executeCommand('humanitec.score.validate');
+
+    await waitForExpect(() => {
+      const diagnostics = vscode.languages.getDiagnostics(doc.uri);
+      expect(diagnostics).not.to.be.empty;
+      expect(statusBarItemShow).to.have.been.called;
+      expect(statusBarItem.text).to.be.eq('$(warning) Only local validation');
+      expect(statusBarItem.tooltip).to.be.eq(
+        'There is no organization set so Humanitec Extension could only validate the Score files locally'
+      );
+    });
+  });
+
+  test('given user is logged and workspace has valid organization in use, should validate the Score files remotely', async () => {
+    await vscode.workspace
+      .getConfiguration('humanitec')
+      .update('organization', humanitecOrg);
+
+    await vscode.commands.executeCommand('humanitec.score.validate');
+
+    await waitForExpect(() => {
+      const diagnostics = vscode.languages.getDiagnostics(doc.uri);
+      expect(diagnostics).not.to.be.empty;
+      const messages = diagnostics.map(diagnostic => diagnostic.message);
+      expect(messages).to.contain.any.members([
+        `additionalProperties 'invalid' not allowed`,
+      ]);
+      expect(statusBarItemHide.called).to.be.true;
+    });
+  });
+
+  test('given user is logged and workspace has invalid organization in use, should validate the Score files remotely', async () => {
+    await vscode.workspace
+      .getConfiguration('humanitec')
+      .update('organization', 'invalid');
+
+    await vscode.commands.executeCommand('humanitec.score.validate');
+
+    await waitForExpect(() => {
+      expect(errorMessageShow).to.have.been.calledWith(
+        'Invalid or empty Humanitec token. Login to Humanitec using "Humanitec: Login" or set your token using "Humanitec: Set token" command.'
+      );
+    });
+  });
+});

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -1,0 +1,9 @@
+export const wait = (ms: number) =>
+  new Promise<void>(resolve => setTimeout(() => resolve(), ms));
+
+export const readEnv = (name: string): string => {
+  if (!process.env[name]) {
+    throw new Error(`${name} not set`);
+  }
+  return process.env[name] || '';
+};


### PR DESCRIPTION
If there is no org set the local validation is executed with the proper status displayed in the status bar

![Zrzut ekranu 2024-06-13 o 10 14 15](https://github.com/humanitec/vscode-humanitec/assets/27313042/54f3f59b-944c-414b-9164-bd47418a79b2)
