### PR TITLE
fix: open resource type doc do not scroll to selected type

### DIFF
--- a/scripts/download-humctl.js
+++ b/scripts/download-humctl.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const CLI_VERSION = '0.25.1';
+const CLI_VERSION = '0.28.0';
 
 const fs = require('node:fs/promises');
 const extractZip = require('extract-zip');

--- a/src/adapters/humctl/HumctlAdapter.ts
+++ b/src/adapters/humctl/HumctlAdapter.ts
@@ -42,7 +42,7 @@ export class HumctlAdapter implements IHumctlAdapter {
       throw new UnsupportedOperatingSystemError(os, arch);
     }
 
-    let humctlEmbeddedBinaryFilename = `cli_0.25.1_${os}_${arch}`;
+    let humctlEmbeddedBinaryFilename = `cli_0.28.0_${os}_${arch}`;
     if (os === 'win32') {
       humctlEmbeddedBinaryFilename += '.exe';
     }

--- a/src/controllers/HumanitecSidebarController.ts
+++ b/src/controllers/HumanitecSidebarController.ts
@@ -1,7 +1,9 @@
 import * as vscode from 'vscode';
-import { AvailableResourceTypesProvider } from '../providers/AvailableResourceTypesProvider';
+import {
+  AvailableResourceTypesProvider,
+  ResourceTypeTreeItem,
+} from '../providers/AvailableResourceTypesProvider';
 import { IResourceTypeRepository } from '../repos/ResourceTypeRepository';
-import { ResourceType } from '../domain/ResourceType';
 import { ILoggerService } from '../services/LoggerService';
 import { isHumanitecExtensionError } from '../errors/IHumanitecExtensionError';
 import {
@@ -106,7 +108,7 @@ export class HumanitecSidebarController {
 
     disposable = vscode.commands.registerCommand(
       'humanitec.sidebar.availableResources.open_resource_type_doc',
-      async (resourceType: ResourceType) => {
+      async (resourceType: ResourceTypeTreeItem) => {
         try {
           let url = vscode.Uri.parse(
             'https://developer.humanitec.com/platform-orchestrator/reference/resource-types/'
@@ -114,7 +116,7 @@ export class HumanitecSidebarController {
           if (resourceType !== undefined) {
             url = vscode.Uri.parse(
               'https://developer.humanitec.com/platform-orchestrator/reference/resource-types/#' +
-                resourceType.type
+                resourceType.resourceType
             );
           }
           vscode.env.openExternal(url);

--- a/src/providers/AvailableResourceTypesProvider.ts
+++ b/src/providers/AvailableResourceTypesProvider.ts
@@ -87,7 +87,7 @@ export type AvailableResourceTypesTreeItem =
   | ResourceTypePropertyTreeItem
   | ResourceTypePropertyValueTreeItem;
 
-class ResourceTypeTreeItem extends vscode.TreeItem {
+export class ResourceTypeTreeItem extends vscode.TreeItem {
   constructor(
     public readonly resourceType: string,
     public readonly name: string


### PR DESCRIPTION
This PR updates the `humctl` client to a latest version that includes enhanced resource type classes. It also fixes the issue where clicking to open a resource type document does not scroll to the selected type