### PR TITLE
fix: validation returns illegal state error

### DIFF
--- a/src/services/ErrorHandlerService.ts
+++ b/src/services/ErrorHandlerService.ts
@@ -17,6 +17,11 @@ export class ErrorHandlerService implements IErrorHandlerService {
       this.logger.error(error.details());
       this.showErrorMessage(error.message());
     } else if (error instanceof Error) {
+      // Validation may fail if the document changed (object is already disposed) during the validation process
+      if (error.message === 'illegal state - object is disposed') {
+        return;
+      }
+
       this.logger.error(
         JSON.stringify({
           message: error.message,


### PR DESCRIPTION
This PR simply ignores `illegal state - object is disposed` as it occurred when the object (in this example document) is already disposed.

```
[ERROR] {"message":"illegal state - object is disposed","stack":"Error: illegal state - object is disposed\n    at Q3.j (file:///Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:137:95055)\n    at Q3.set (file:///Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/workbench/api/node/extensionHostProcess.js:137:93515)\n    at ValidateScoreFileController.validate (/Users/mjenek/.vscode/extensions/humanitec.humanitec-0.2.3/out/controllers/ValidateScoreFileController.js:154:30)\n    at /Users/mjenek/.vscode/extensions/humanitec.humanitec-0.2.3/out/controllers/ValidateScoreFileController.js:90:21","name":"Error"}
```

![Zrzut ekranu 2024-10-25 o 17 15 39](https://github.com/user-attachments/assets/6a07e3ff-a238-484e-a271-cb5c2260727a)
