### PR TITLE
fix: remove set_in_workspace cmd from palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,12 @@
       ]
     },
     "menus": {
+      "commandPalette": [
+        {
+          "command": "humanitec.sidebar.organization_structure.set_in_workspace",
+          "when": "false"
+        }
+      ],
       "view/title": [
         {
           "command": "humanitec.sidebar.availableResources.refreshEntries",


### PR DESCRIPTION
This PR removes `set_in_workspace` command from command palette. This command is intended to be executed only from the extension sidebar