### PR TITLE
fix: ci do not build webview

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,12 +27,16 @@ jobs:
       - name: Authenticate with private NPM package
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
 
+      - name: Install graph webview dependencies
+        working-directory: ./webview/resource-dependency-graph
+        run: npm install
+
       - name: Build graph webview
         working-directory: ./webview/resource-dependency-graph
-        run: npm ci
+        run: npm run build
 
       - run: npm ci
-
+      
       - run: npm run lint
         if: runner.os == 'Linux'
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -38,6 +38,11 @@ export default tseslint.config(
   },
   eslintPluginPrettierRecommended,
   {
-    ignores: ['out/', 'dist/', '.vscode-test/'],
+    ignores: [
+      'out/',
+      'dist/',
+      '.vscode-test/',
+      'webview/resource-dependency-graph/dist/',
+    ],
   }
 );

--- a/webview/resource-dependency-graph/package-lock.json
+++ b/webview/resource-dependency-graph/package-lock.json
@@ -27,7 +27,8 @@
       },
       "devDependencies": {
         "@types/styled-components": "^5.1.34",
-        "parcel": "^2.13.0",
+        "buffer": "^5.5.0",
+        "parcel": "^2.13.3",
         "process": "^0.11.10"
       }
     },
@@ -3573,22 +3574,22 @@
       }
     },
     "node_modules/@parcel/bundler-default": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.13.0.tgz",
-      "integrity": "sha512-qx6v8mBJkgiEeNXZwzW+1x0YZ3lpkx/WDmqa63GE/CUWSIlMb14ZELyXewAo7mzX99qDhV4E6+OX1vRUI47+nQ==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.13.3.tgz",
+      "integrity": "sha512-mOuWeth0bZzRv1b9Lrvydis/hAzJyePy0gwa0tix3/zyYBvw0JY+xkXVR4qKyD/blc1Ra2qOlfI2uD3ucnsdXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.0",
-        "@parcel/graph": "3.3.0",
-        "@parcel/plugin": "2.13.0",
-        "@parcel/rust": "2.13.0",
-        "@parcel/utils": "2.13.0",
+        "@parcel/diagnostic": "2.13.3",
+        "@parcel/graph": "3.3.3",
+        "@parcel/plugin": "2.13.3",
+        "@parcel/rust": "2.13.3",
+        "@parcel/utils": "2.13.3",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -3596,15 +3597,15 @@
       }
     },
     "node_modules/@parcel/cache": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.13.0.tgz",
-      "integrity": "sha512-8GA4Dmhu917a5ZAfLgc7G3gDEWOkFhxeoY44eU7WYgh12rSJCS9XVIaWVnzDKb0ou3brSpbVKz9rhNj1K7kmPw==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.13.3.tgz",
+      "integrity": "sha512-Vz5+K5uCt9mcuQAMDo0JdbPYDmVdB8Nvu/A2vTEK2rqZPxvoOTczKeMBA4JqzKqGURHPRLaJCvuR8nDG+jhK9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/fs": "2.13.0",
-        "@parcel/logger": "2.13.0",
-        "@parcel/utils": "2.13.0",
+        "@parcel/fs": "2.13.3",
+        "@parcel/logger": "2.13.3",
+        "@parcel/utils": "2.13.3",
         "lmdb": "2.8.5"
       },
       "engines": {
@@ -3615,13 +3616,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.0"
+        "@parcel/core": "^2.13.3"
       }
     },
     "node_modules/@parcel/codeframe": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.13.0.tgz",
-      "integrity": "sha512-mKOQSDmRzWqC/ELwjGv9ZDqkYtHwkwvpLC4gb5mUAw6VJsDqraydtluxGR2NejYwETiS4j9mQElcbHZoRcZ9uA==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.13.3.tgz",
+      "integrity": "sha512-L/PQf+PT0xM8k9nc0B+PxxOYO2phQYnbuifu9o4pFRiqVmCtHztP+XMIvRJ2gOEXy3pgAImSPFVJ3xGxMFky4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3636,17 +3637,17 @@
       }
     },
     "node_modules/@parcel/compressor-raw": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.13.0.tgz",
-      "integrity": "sha512-T6+qN36Rci/D3C79vImzZyQyReKOqKQetWAG2n3PG780mt+6omTGyZKRVUQTxJIbStgttlL9ZRlTHFiQeid7rg==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.13.3.tgz",
+      "integrity": "sha512-C6vjDlgTLjYc358i7LA/dqcL0XDQZ1IHXFw6hBaHHOfxPKW2T4bzUI6RURyToEK9Q1X7+ggDKqgdLxwp4veCFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.0"
+        "@parcel/plugin": "2.13.3"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -3654,75 +3655,75 @@
       }
     },
     "node_modules/@parcel/config-default": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.13.0.tgz",
-      "integrity": "sha512-clxN5xXeVrq6GhxrKWoQi0BkmLYmbfttoXA/zXsX2XF15QZALHqQtUKuKh2LLZj4NmwplTkIRz5vT80n8uvLOQ==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.13.3.tgz",
+      "integrity": "sha512-WUsx83ic8DgLwwnL1Bua4lRgQqYjxiTT+DBxESGk1paNm1juWzyfPXEQDLXwiCTcWMQGiXQFQ8OuSISauVQ8dQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/bundler-default": "2.13.0",
-        "@parcel/compressor-raw": "2.13.0",
-        "@parcel/namer-default": "2.13.0",
-        "@parcel/optimizer-css": "2.13.0",
-        "@parcel/optimizer-htmlnano": "2.13.0",
-        "@parcel/optimizer-image": "2.13.0",
-        "@parcel/optimizer-svgo": "2.13.0",
-        "@parcel/optimizer-swc": "2.13.0",
-        "@parcel/packager-css": "2.13.0",
-        "@parcel/packager-html": "2.13.0",
-        "@parcel/packager-js": "2.13.0",
-        "@parcel/packager-raw": "2.13.0",
-        "@parcel/packager-svg": "2.13.0",
-        "@parcel/packager-wasm": "2.13.0",
-        "@parcel/reporter-dev-server": "2.13.0",
-        "@parcel/resolver-default": "2.13.0",
-        "@parcel/runtime-browser-hmr": "2.13.0",
-        "@parcel/runtime-js": "2.13.0",
-        "@parcel/runtime-react-refresh": "2.13.0",
-        "@parcel/runtime-service-worker": "2.13.0",
-        "@parcel/transformer-babel": "2.13.0",
-        "@parcel/transformer-css": "2.13.0",
-        "@parcel/transformer-html": "2.13.0",
-        "@parcel/transformer-image": "2.13.0",
-        "@parcel/transformer-js": "2.13.0",
-        "@parcel/transformer-json": "2.13.0",
-        "@parcel/transformer-postcss": "2.13.0",
-        "@parcel/transformer-posthtml": "2.13.0",
-        "@parcel/transformer-raw": "2.13.0",
-        "@parcel/transformer-react-refresh-wrap": "2.13.0",
-        "@parcel/transformer-svg": "2.13.0"
+        "@parcel/bundler-default": "2.13.3",
+        "@parcel/compressor-raw": "2.13.3",
+        "@parcel/namer-default": "2.13.3",
+        "@parcel/optimizer-css": "2.13.3",
+        "@parcel/optimizer-htmlnano": "2.13.3",
+        "@parcel/optimizer-image": "2.13.3",
+        "@parcel/optimizer-svgo": "2.13.3",
+        "@parcel/optimizer-swc": "2.13.3",
+        "@parcel/packager-css": "2.13.3",
+        "@parcel/packager-html": "2.13.3",
+        "@parcel/packager-js": "2.13.3",
+        "@parcel/packager-raw": "2.13.3",
+        "@parcel/packager-svg": "2.13.3",
+        "@parcel/packager-wasm": "2.13.3",
+        "@parcel/reporter-dev-server": "2.13.3",
+        "@parcel/resolver-default": "2.13.3",
+        "@parcel/runtime-browser-hmr": "2.13.3",
+        "@parcel/runtime-js": "2.13.3",
+        "@parcel/runtime-react-refresh": "2.13.3",
+        "@parcel/runtime-service-worker": "2.13.3",
+        "@parcel/transformer-babel": "2.13.3",
+        "@parcel/transformer-css": "2.13.3",
+        "@parcel/transformer-html": "2.13.3",
+        "@parcel/transformer-image": "2.13.3",
+        "@parcel/transformer-js": "2.13.3",
+        "@parcel/transformer-json": "2.13.3",
+        "@parcel/transformer-postcss": "2.13.3",
+        "@parcel/transformer-posthtml": "2.13.3",
+        "@parcel/transformer-raw": "2.13.3",
+        "@parcel/transformer-react-refresh-wrap": "2.13.3",
+        "@parcel/transformer-svg": "2.13.3"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.0"
+        "@parcel/core": "^2.13.3"
       }
     },
     "node_modules/@parcel/core": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.13.0.tgz",
-      "integrity": "sha512-ok2y14uJebDuDz5QGcv+Ui4cjdroV/L5HUorYDfttNbuxjc4XpLJC9bzfu3MSwVKF44n/prT9pt3AK/Vf1LFDg==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.13.3.tgz",
+      "integrity": "sha512-SRZFtqGiaKHlZ2YAvf+NHvBFWS3GnkBvJMfOJM7kxJRK3M1bhbwJa/GgSdzqro5UVf9Bfj6E+pkdrRQIOZ7jMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/cache": "2.13.0",
-        "@parcel/diagnostic": "2.13.0",
-        "@parcel/events": "2.13.0",
-        "@parcel/feature-flags": "2.13.0",
-        "@parcel/fs": "2.13.0",
-        "@parcel/graph": "3.3.0",
-        "@parcel/logger": "2.13.0",
-        "@parcel/package-manager": "2.13.0",
-        "@parcel/plugin": "2.13.0",
-        "@parcel/profiler": "2.13.0",
-        "@parcel/rust": "2.13.0",
+        "@parcel/cache": "2.13.3",
+        "@parcel/diagnostic": "2.13.3",
+        "@parcel/events": "2.13.3",
+        "@parcel/feature-flags": "2.13.3",
+        "@parcel/fs": "2.13.3",
+        "@parcel/graph": "3.3.3",
+        "@parcel/logger": "2.13.3",
+        "@parcel/package-manager": "2.13.3",
+        "@parcel/plugin": "2.13.3",
+        "@parcel/profiler": "2.13.3",
+        "@parcel/rust": "2.13.3",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.13.0",
-        "@parcel/utils": "2.13.0",
-        "@parcel/workers": "2.13.0",
+        "@parcel/types": "2.13.3",
+        "@parcel/utils": "2.13.3",
+        "@parcel/workers": "2.13.3",
         "base-x": "^3.0.8",
         "browserslist": "^4.6.6",
         "clone": "^2.1.1",
@@ -3742,9 +3743,9 @@
       }
     },
     "node_modules/@parcel/core/node_modules/dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -3771,9 +3772,9 @@
       }
     },
     "node_modules/@parcel/diagnostic": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.13.0.tgz",
-      "integrity": "sha512-ocgqebLD4VL7/zkOoNBcIRu4ndFRipPwNkLd9cdfux3QBYuYBi5DE+3RSt9IWMrwjS8DMFXCxmtNANr7zujgjw==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.13.3.tgz",
+      "integrity": "sha512-C70KXLBaXLJvr7XCEVu8m6TqNdw1gQLxqg5BQ8roR62R4vWWDnOq8PEksxDi4Y8Z/FF4i3Sapv6tRx9iBNxDEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3789,9 +3790,9 @@
       }
     },
     "node_modules/@parcel/events": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.13.0.tgz",
-      "integrity": "sha512-vFB/GebsoiSxQy68DvrX8zpeJP2xWhSNYSN99ZbyADxutiAUnquu4nKMJCp4Pb+gNPHr2TitU6LKNGXqWLEE7w==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.13.3.tgz",
+      "integrity": "sha512-ZkSHTTbD/E+53AjUzhAWTnMLnxLEU5yRw0H614CaruGh+GjgOIKyukGeToF5Gf/lvZ159VrJCGE0Z5EpgHVkuQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3803,9 +3804,9 @@
       }
     },
     "node_modules/@parcel/feature-flags": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/feature-flags/-/feature-flags-2.13.0.tgz",
-      "integrity": "sha512-HNTUy7DfEuowGqkKq2DGwhGEO9U3ORgIgRyxG4cXHMhx9BIE1lmB3ZVfu+dyq34GSYw6ceOgo0I3BZYs7rRKDA==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/feature-flags/-/feature-flags-2.13.3.tgz",
+      "integrity": "sha512-UZm14QpamDFoUut9YtCZSpG1HxPs07lUwUCpsAYL0PpxASD3oWJQxIJGfDZPa2272DarXDG9adTKrNXvkHZblw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3817,18 +3818,18 @@
       }
     },
     "node_modules/@parcel/fs": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.13.0.tgz",
-      "integrity": "sha512-qMaTdlrmnZPk7jy5+FC0xdE5tqzGutRhcoEKGTvtbjEBh++azw9mKkGxLe2CQXnoJXydvM++dhUUIsKhchQGxA==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.13.3.tgz",
+      "integrity": "sha512-+MPWAt0zr+TCDSlj1LvkORTjfB/BSffsE99A9AvScKytDSYYpY2s0t4vtV9unSh0FHMS2aBCZNJ4t7KL+DcPIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/feature-flags": "2.13.0",
-        "@parcel/rust": "2.13.0",
-        "@parcel/types-internal": "2.13.0",
-        "@parcel/utils": "2.13.0",
+        "@parcel/feature-flags": "2.13.3",
+        "@parcel/rust": "2.13.3",
+        "@parcel/types-internal": "2.13.3",
+        "@parcel/utils": "2.13.3",
         "@parcel/watcher": "^2.0.7",
-        "@parcel/workers": "2.13.0"
+        "@parcel/workers": "2.13.3"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -3838,17 +3839,17 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.0"
+        "@parcel/core": "^2.13.3"
       }
     },
     "node_modules/@parcel/graph": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.3.0.tgz",
-      "integrity": "sha512-CMiX+yzpZH4clrHIbWqH7Pz2tfdS4C22WbcpUMvS4W+U97BhY4B6mm4ytEUOmyqKWiFNGFTfGwZKst9RjSLE6A==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.3.3.tgz",
+      "integrity": "sha512-pxs4GauEdvCN8nRd6wG3st6LvpHske3GfqGwUSR0P0X0pBPI1/NicvXz6xzp3rgb9gPWfbKXeI/2IOTfIxxVfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/feature-flags": "2.13.0",
+        "@parcel/feature-flags": "2.13.3",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -3860,14 +3861,14 @@
       }
     },
     "node_modules/@parcel/logger": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.13.0.tgz",
-      "integrity": "sha512-/hWNC27PntVH+GugndqPYflucG8a9Octc6fuQWS40oBZSw5kBQBYs4xkBSkTVLpcI8910HN3aSHjOJIX8ddtRg==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.13.3.tgz",
+      "integrity": "sha512-8YF/ZhsQgd7ohQ2vEqcMD1Ag9JlJULROWRPGgGYLGD+twuxAiSdiFBpN3f+j4gQN4PYaLaIS/SwUFx11J243fQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.0",
-        "@parcel/events": "2.13.0"
+        "@parcel/diagnostic": "2.13.3",
+        "@parcel/events": "2.13.3"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -3878,9 +3879,9 @@
       }
     },
     "node_modules/@parcel/markdown-ansi": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.13.0.tgz",
-      "integrity": "sha512-kznmctJ7myhu7/JKN9njHudBj4t8bv4oKW4/cvWgzVR7ftsw9oOJ8EE7eqtqOzzInyATZxXmbk+EYX4S04vLUg==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.13.3.tgz",
+      "integrity": "sha512-B4rUdlNUulJs2xOQuDbN7Hq5a9roq8IZUcJ1vQ8PAv+zMGb7KCfqIIr/BSCDYGhayfAGBVWW8x55Kvrl1zrDYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3895,19 +3896,19 @@
       }
     },
     "node_modules/@parcel/namer-default": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.13.0.tgz",
-      "integrity": "sha512-D4NbhiSr9sG0OUE0TpLWCuFtwZDexfQpug4MGF0qBKTDb0urVxd6peITU2cuJJ2Y615kagGHNiw14qJ62MpIgA==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.13.3.tgz",
+      "integrity": "sha512-A2a5A5fuyNcjSGOS0hPcdQmOE2kszZnLIXof7UMGNkNkeC62KAG8WcFZH5RNOY3LT5H773hq51zmc2Y2gE5Rnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.0",
-        "@parcel/plugin": "2.13.0",
+        "@parcel/diagnostic": "2.13.3",
+        "@parcel/plugin": "2.13.3",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -3915,17 +3916,17 @@
       }
     },
     "node_modules/@parcel/node-resolver-core": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.4.0.tgz",
-      "integrity": "sha512-LFbbdUTcrbFI8fYDPk86mJc2SANPZzECTfsrqhx1u36t33iYmJTuGnYUH32unT5ra60KOmeZWny8yqedeyHwuw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.4.3.tgz",
+      "integrity": "sha512-IEnMks49egEic1ITBp59VQyHzkSQUXqpU9hOHwqN3KoSTdZ6rEgrXcS3pa6tdXay4NYGlcZ88kFCE8i/xYoVCg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
-        "@parcel/diagnostic": "2.13.0",
-        "@parcel/fs": "2.13.0",
-        "@parcel/rust": "2.13.0",
-        "@parcel/utils": "2.13.0",
+        "@parcel/diagnostic": "2.13.3",
+        "@parcel/fs": "2.13.3",
+        "@parcel/rust": "2.13.3",
+        "@parcel/utils": "2.13.3",
         "nullthrows": "^1.1.1",
         "semver": "^7.5.2"
       },
@@ -3938,23 +3939,23 @@
       }
     },
     "node_modules/@parcel/optimizer-css": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.13.0.tgz",
-      "integrity": "sha512-rB+zltYJaHTqaiVSYkZfYns6bkk4X9AG0AuD78VpGnGhcramle0bvsB8w6zOOtseY66m1+nlYUe6OPw6jrE6Lg==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.13.3.tgz",
+      "integrity": "sha512-A8o9IVCv919vhv69SkLmyW2WjJR5WZgcMqV6L1uiGF8i8z18myrMhrp2JuSHx29PRT9uNyzNC4Xrd4StYjIhJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.0",
-        "@parcel/plugin": "2.13.0",
+        "@parcel/diagnostic": "2.13.3",
+        "@parcel/plugin": "2.13.3",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.13.0",
+        "@parcel/utils": "2.13.3",
         "browserslist": "^4.6.6",
         "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -3962,22 +3963,22 @@
       }
     },
     "node_modules/@parcel/optimizer-htmlnano": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.13.0.tgz",
-      "integrity": "sha512-69Of5qyiWAAHCKyrqg7NbkriuonzowAysIOQNjQPuy5HVMy+hJjUmgikCcwfRxmV+7af/DRlBYGo0ay6wzH/7w==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.13.3.tgz",
+      "integrity": "sha512-K4Uvg0Sy2pECP7pdvvbud++F0pfcbNkq+IxTrgqBX5HJnLEmRZwgdvZEKF43oMEolclMnURMQRGjRplRaPdbXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.0",
-        "@parcel/plugin": "2.13.0",
-        "@parcel/utils": "2.13.0",
+        "@parcel/diagnostic": "2.13.3",
+        "@parcel/plugin": "2.13.3",
+        "@parcel/utils": "2.13.3",
         "htmlnano": "^2.0.0",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -4243,9 +4244,9 @@
       }
     },
     "node_modules/@parcel/optimizer-htmlnano/node_modules/domutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
@@ -4336,9 +4337,9 @@
       }
     },
     "node_modules/@parcel/optimizer-htmlnano/node_modules/lilconfig": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
-      "integrity": "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4360,15 +4361,15 @@
       "peer": true
     },
     "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-calc": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-10.0.2.tgz",
-      "integrity": "sha512-DT/Wwm6fCKgpYVI7ZEWuPJ4az8hiEHtCUeYjZXqU7Ou4QqYh1Df2yCQ7Ca6N7xqKPFkxN3fhf+u9KSoOCJNAjg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-10.1.0.tgz",
+      "integrity": "sha512-uQ/LDGsf3mgsSUEXmAt3VsCSHR3aKqtEIkmB+4PhzYwRYOW5MZs/GhCCFpsOtJJkP6EC6uGipbrnaTjqaJZcJw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "postcss-selector-parser": "^6.1.2",
+        "postcss-selector-parser": "^7.0.0",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
@@ -4376,6 +4377,22 @@
       },
       "peerDependencies": {
         "postcss": "^8.4.38"
+      }
+    },
+    "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-calc/node_modules/postcss-selector-parser": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
+      "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@parcel/optimizer-htmlnano/node_modules/postcss-colormin": {
@@ -4914,44 +4931,44 @@
       }
     },
     "node_modules/@parcel/optimizer-image": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.13.0.tgz",
-      "integrity": "sha512-lCcmUrH91PKLLInADr8k+gEjvGTox4D9XGQkU3o88M+h7nBM0Tx2mKrDjWlMhFag73juc2vuMQKyjt7Sszk+MQ==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.13.3.tgz",
+      "integrity": "sha512-wlDUICA29J4UnqkKrWiyt68g1e85qfYhp4zJFcFJL0LX1qqh1QwsLUz3YJ+KlruoqPxJSFEC8ncBEKiVCsqhEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.0",
-        "@parcel/plugin": "2.13.0",
-        "@parcel/rust": "2.13.0",
-        "@parcel/utils": "2.13.0",
-        "@parcel/workers": "2.13.0"
+        "@parcel/diagnostic": "2.13.3",
+        "@parcel/plugin": "2.13.3",
+        "@parcel/rust": "2.13.3",
+        "@parcel/utils": "2.13.3",
+        "@parcel/workers": "2.13.3"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.0"
+        "@parcel/core": "^2.13.3"
       }
     },
     "node_modules/@parcel/optimizer-svgo": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.13.0.tgz",
-      "integrity": "sha512-dksW0u0IdA73VhutwDYnNhY/Yl5xscm+bia0zmm+02wr11PRW6nvsxvIyFSI/lU0+gsk7nMMxeSqWuPFDJWfrw==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.13.3.tgz",
+      "integrity": "sha512-piIKxQKzhZK54dJR6yqIcq+urZmpsfgUpLCZT3cnWlX4ux5+S2iN66qqZBs0zVn+a58LcWcoP4Z9ieiJmpiu2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.0",
-        "@parcel/plugin": "2.13.0",
-        "@parcel/utils": "2.13.0"
+        "@parcel/diagnostic": "2.13.3",
+        "@parcel/plugin": "2.13.3",
+        "@parcel/utils": "2.13.3"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -4959,22 +4976,22 @@
       }
     },
     "node_modules/@parcel/optimizer-swc": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.13.0.tgz",
-      "integrity": "sha512-tBo1kn003BJh3dkGQ3Yd5Gsf9yTS+O8G/U0eSvFb/2Xov/Syx98yNFN9JJv9rOf/agJ7Ism3LjbgBEzDDjzZ0w==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.13.3.tgz",
+      "integrity": "sha512-zNSq6oWqLlW8ksPIDjM0VgrK6ZAJbPQCDvs1V+p0oX3CzEe85lT5VkRpnfrN1+/vvEJNGL8e60efHKpI+rXGTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.0",
-        "@parcel/plugin": "2.13.0",
+        "@parcel/diagnostic": "2.13.3",
+        "@parcel/plugin": "2.13.3",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.13.0",
+        "@parcel/utils": "2.13.3",
         "@swc/core": "^1.7.26",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -4982,19 +4999,19 @@
       }
     },
     "node_modules/@parcel/package-manager": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.13.0.tgz",
-      "integrity": "sha512-S8cnSFpJUkPFSvrWc886nDHVTUGWqdCaoA5R8BJ8I8fMOu6pSUkkUexqK5yYnN7S0dn1bLMnKU3ARpwXhOUZJw==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.13.3.tgz",
+      "integrity": "sha512-FLNI5OrZxymGf/Yln0E/kjnGn5sdkQAxW7pQVdtuM+5VeN75yibJRjsSGv88PvJ+KvpD2ANgiIJo1RufmoPcww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.0",
-        "@parcel/fs": "2.13.0",
-        "@parcel/logger": "2.13.0",
-        "@parcel/node-resolver-core": "3.4.0",
-        "@parcel/types": "2.13.0",
-        "@parcel/utils": "2.13.0",
-        "@parcel/workers": "2.13.0",
+        "@parcel/diagnostic": "2.13.3",
+        "@parcel/fs": "2.13.3",
+        "@parcel/logger": "2.13.3",
+        "@parcel/node-resolver-core": "3.4.3",
+        "@parcel/types": "2.13.3",
+        "@parcel/utils": "2.13.3",
+        "@parcel/workers": "2.13.3",
         "@swc/core": "^1.7.26",
         "semver": "^7.5.2"
       },
@@ -5006,26 +5023,26 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.0"
+        "@parcel/core": "^2.13.3"
       }
     },
     "node_modules/@parcel/packager-css": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.13.0.tgz",
-      "integrity": "sha512-Zgf2lr0erqiCh4zqmGjnuo63Q6JhouXfYNVTXYWEf+vgCnSanuy7q4e17YC6SU4QmHdy6IF0zoAz1D+x23hsQA==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.13.3.tgz",
+      "integrity": "sha512-ghDqRMtrUwaDERzFm9le0uz2PTeqqsjsW0ihQSZPSAptElRl9o5BR+XtMPv3r7Ui0evo+w35gD55oQCJ28vCig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.0",
-        "@parcel/plugin": "2.13.0",
+        "@parcel/diagnostic": "2.13.3",
+        "@parcel/plugin": "2.13.3",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.13.0",
+        "@parcel/utils": "2.13.3",
         "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5033,21 +5050,21 @@
       }
     },
     "node_modules/@parcel/packager-html": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.13.0.tgz",
-      "integrity": "sha512-L/QrmiG3Zib3WnPy7kxC8njT4r8yvIpNveyv2NE8MRwwlsHf5GytTyK0euRPVLlnl4wCg3z15nrA3081E/OPjw==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.13.3.tgz",
+      "integrity": "sha512-jDLnKSA/EzVEZ3/aegXO3QJ/Ij732AgBBkIQfeC8tUoxwVz5b3HiPBAjVjcUSfZs7mdBSHO+ELWC3UD+HbsIrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.0",
-        "@parcel/types": "2.13.0",
-        "@parcel/utils": "2.13.0",
+        "@parcel/plugin": "2.13.3",
+        "@parcel/types": "2.13.3",
+        "@parcel/utils": "2.13.3",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5055,24 +5072,24 @@
       }
     },
     "node_modules/@parcel/packager-js": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.13.0.tgz",
-      "integrity": "sha512-aObsQMSTyZtyvozuAoIRH3Qr7Xqcp+7w8mZNbhxjQsReQoRcnWfoN02yJ658f9vy+JT5lQkgdkNN3k6YfI7lsw==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.13.3.tgz",
+      "integrity": "sha512-0pMHHf2zOn7EOJe88QJw5h/wcV1bFfj6cXVcE55Wa8GX3V+SdCgolnlvNuBcRQ1Tlx0Xkpo+9hMFVIQbNQY6zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.0",
-        "@parcel/plugin": "2.13.0",
-        "@parcel/rust": "2.13.0",
+        "@parcel/diagnostic": "2.13.3",
+        "@parcel/plugin": "2.13.3",
+        "@parcel/rust": "2.13.3",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/types": "2.13.0",
-        "@parcel/utils": "2.13.0",
+        "@parcel/types": "2.13.3",
+        "@parcel/utils": "2.13.3",
         "globals": "^13.2.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5109,17 +5126,17 @@
       }
     },
     "node_modules/@parcel/packager-raw": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.13.0.tgz",
-      "integrity": "sha512-HiLdxaMk588NfUh2ROyOORMaz1kDoPqZzcShz32U9q2kangFSFJmUN+5Sqdw1eSN/cVmK7StWsRyMulGJ+mbgQ==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.13.3.tgz",
+      "integrity": "sha512-AWu4UB+akBdskzvT3KGVHIdacU9f7cI678DQQ1jKQuc9yZz5D0VFt3ocFBOmvDfEQDF0uH3jjtJR7fnuvX7Biw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.0"
+        "@parcel/plugin": "2.13.3"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5127,20 +5144,20 @@
       }
     },
     "node_modules/@parcel/packager-svg": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.13.0.tgz",
-      "integrity": "sha512-hzSKpgXO/d1vzMFDXe4qjsuDoPTcclkX/41CJ1WWtKmBtU7UVK2BEq+hfps4ZrE04cER/0ZvxrrH4xXviYKsig==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.13.3.tgz",
+      "integrity": "sha512-tKGRiFq/4jh5u2xpTstNQ7gu+RuZWzlWqpw5NaFmcKe6VQe5CMcS499xTFoREAGnRvevSeIgC38X1a+VOo+/AA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.0",
-        "@parcel/types": "2.13.0",
-        "@parcel/utils": "2.13.0",
+        "@parcel/plugin": "2.13.3",
+        "@parcel/types": "2.13.3",
+        "@parcel/utils": "2.13.3",
         "posthtml": "^0.16.4"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5148,17 +5165,17 @@
       }
     },
     "node_modules/@parcel/packager-wasm": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.13.0.tgz",
-      "integrity": "sha512-2KJnDQhDCU8E79zeUYMy3t6DPC0o1lg8KqvW6cVFS6Cr9Lot5YRzMGSY6/2M3upXK6M9TigfGs21WEcdf10tLw==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.13.3.tgz",
+      "integrity": "sha512-SZB56/b230vFrSehVXaUAWjJmWYc89gzb8OTLkBm7uvtFtov2J1R8Ig9TTJwinyXE3h84MCFP/YpQElSfoLkJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.0"
+        "@parcel/plugin": "2.13.3"
       },
       "engines": {
         "node": ">=16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5166,13 +5183,13 @@
       }
     },
     "node_modules/@parcel/plugin": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.13.0.tgz",
-      "integrity": "sha512-Q00Zv+zJ+rx+C/bHVNscXot1/cPm7Xx2H/NaJpwoXGg1+GNJFRYI37ids5HyWp9H+K67OnM0bC/7VPsTr9NJ0A==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.13.3.tgz",
+      "integrity": "sha512-cterKHHcwg6q11Gpif/aqvHo056TR+yDVJ3fSdiG2xr5KD1VZ2B3hmofWERNNwjMcnR1h9Xq40B7jCKUhOyNFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/types": "2.13.0"
+        "@parcel/types": "2.13.3"
       },
       "engines": {
         "node": ">= 16.0.0"
@@ -5183,15 +5200,15 @@
       }
     },
     "node_modules/@parcel/profiler": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.13.0.tgz",
-      "integrity": "sha512-LW2p0Pfz5TWQprJevN1xHRhqlVm01plCgbzT72qmgjzPMI4QYcZVyG+Y62VGn6iBPivpBqm2TNqdiXzfJreQuw==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.13.3.tgz",
+      "integrity": "sha512-ok6BwWSLvyHe5TuSXjSacYnDStFgP5Y30tA9mbtWSm0INDsYf+m5DqzpYPx8U54OaywWMK8w3MXUClosJX3aPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.0",
-        "@parcel/events": "2.13.0",
-        "@parcel/types-internal": "2.13.0",
+        "@parcel/diagnostic": "2.13.3",
+        "@parcel/events": "2.13.3",
+        "@parcel/types-internal": "2.13.3",
         "chrome-trace-event": "^1.0.2"
       },
       "engines": {
@@ -5203,21 +5220,21 @@
       }
     },
     "node_modules/@parcel/reporter-cli": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.13.0.tgz",
-      "integrity": "sha512-cChHsbp+XrW/3pGZe6Sa+AyWxKRE5uoO9HzFD/r3j6ijCctX2b/Sshs7kmVZLGfDx1GO0u5xU+NzZA8lpFkIkg==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.13.3.tgz",
+      "integrity": "sha512-EA5tKt/6bXYNMEavSs35qHlFdx6cZmRazlZxPBgxPePQYoouNAPMNLUOEQozaPhz9f5fvNDN7EHOFaAWcdO2LA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.0",
-        "@parcel/types": "2.13.0",
-        "@parcel/utils": "2.13.0",
+        "@parcel/plugin": "2.13.3",
+        "@parcel/types": "2.13.3",
+        "@parcel/utils": "2.13.3",
         "chalk": "^4.1.2",
         "term-size": "^2.2.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5225,18 +5242,18 @@
       }
     },
     "node_modules/@parcel/reporter-dev-server": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.13.0.tgz",
-      "integrity": "sha512-LYm/2peex4aNv5mBqWqSJSpmiGegfuL4i73c3J1zXlcx/lnUIrjAkjh24v+LQsud5Krapqabr19nVlAHpOk33g==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.13.3.tgz",
+      "integrity": "sha512-ZNeFp6AOIQFv7mZIv2P5O188dnZHNg0ymeDVcakfZomwhpSva2dFNS3AnvWo4eyWBlUxkmQO8BtaxeWTs7jAuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.0",
-        "@parcel/utils": "2.13.0"
+        "@parcel/plugin": "2.13.3",
+        "@parcel/utils": "2.13.3"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5244,20 +5261,20 @@
       }
     },
     "node_modules/@parcel/reporter-tracer": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.13.0.tgz",
-      "integrity": "sha512-POKec53mKPI3XurJUIjaKDl9NHdGzkNONzkjcerHdRHp5W5xUp1KuasKIOQY8tHlvqG0Pp1bytszjDvZB3CnmA==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.13.3.tgz",
+      "integrity": "sha512-aBsVPI8jLZTDkFYrI69GxnsdvZKEYerkPsu935LcX9rfUYssOnmmUP+3oI+8fbg+qNjJuk9BgoQ4hCp9FOphMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.0",
-        "@parcel/utils": "2.13.0",
+        "@parcel/plugin": "2.13.3",
+        "@parcel/utils": "2.13.3",
         "chrome-trace-event": "^1.0.3",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5265,18 +5282,18 @@
       }
     },
     "node_modules/@parcel/resolver-default": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.13.0.tgz",
-      "integrity": "sha512-fdqJ6KnxbZW3Ll65JgHldGiAfVWIhfTVYpnUsh+VvIhranHzn4+JjfevTyjCqx1eLRMxOIjg0uEkwT8d2MOFLw==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.13.3.tgz",
+      "integrity": "sha512-urBZuRALWT9pFMeWQ8JirchLmsQEyI9lrJptiwLbJWrwvmlwSUGkcstmPwoNRf/aAQjICB7ser/247Vny0pFxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/node-resolver-core": "3.4.0",
-        "@parcel/plugin": "2.13.0"
+        "@parcel/node-resolver-core": "3.4.3",
+        "@parcel/plugin": "2.13.3"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5284,18 +5301,18 @@
       }
     },
     "node_modules/@parcel/runtime-browser-hmr": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.13.0.tgz",
-      "integrity": "sha512-5aSVcow/BN8HG3kS1ACY7SKRMm9zaQ9stCpNLtY5HgqwZ+sSC2jtQPeqMnhrSn9ZHunysGJfJ57Xb9Olgjwh5Q==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.13.3.tgz",
+      "integrity": "sha512-EAcPojQFUNUGUrDk66cu3ySPO0NXRVS5CKPd4QrxPCVVbGzde4koKu8krC/TaGsoyUqhie8HMnS70qBP0GFfcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.0",
-        "@parcel/utils": "2.13.0"
+        "@parcel/plugin": "2.13.3",
+        "@parcel/utils": "2.13.3"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5303,20 +5320,20 @@
       }
     },
     "node_modules/@parcel/runtime-js": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.13.0.tgz",
-      "integrity": "sha512-19YxijsDLVs6iGve0ARSkxvz12fgwAXYwvZqXaXn0bZYKHAB5M+Yhd/9fW8/z2NXARfI+hnYWdSaMJAardDltQ==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.13.3.tgz",
+      "integrity": "sha512-62OucNAnxb2Q0uyTFWW/0Hvv2DJ4b5H6neh/YFu2/wmxaZ37xTpEuEcG2do7KW54xE5DeLP+RliHLwi4NvR3ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.0",
-        "@parcel/plugin": "2.13.0",
-        "@parcel/utils": "2.13.0",
+        "@parcel/diagnostic": "2.13.3",
+        "@parcel/plugin": "2.13.3",
+        "@parcel/utils": "2.13.3",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5324,20 +5341,20 @@
       }
     },
     "node_modules/@parcel/runtime-react-refresh": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.13.0.tgz",
-      "integrity": "sha512-RoUpZjdTai85G4lL+gIERJvZlQJfVylqK/BSjTe4udEez6EZlumxxRKnGLo2ciJEJE4o/+yI0eZDkVmGXCj4pQ==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.13.3.tgz",
+      "integrity": "sha512-PYZ1klpJVwqE3WuifILjtF1dugtesHEuJcXYZI85T6UoRSD5ctS1nAIpZzT14Ga1lRt/jd+eAmhWL1l3m/Vk1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.0",
-        "@parcel/utils": "2.13.0",
+        "@parcel/plugin": "2.13.3",
+        "@parcel/utils": "2.13.3",
         "react-error-overlay": "6.0.9",
         "react-refresh": ">=0.9 <=0.14"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5352,19 +5369,19 @@
       "license": "MIT"
     },
     "node_modules/@parcel/runtime-service-worker": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.13.0.tgz",
-      "integrity": "sha512-UcYIwEbfjdsHeDU/7f28uzz9gdffhkqP2mQeAwyn5okMb4yaWNxx0lCzcMigC5ORy7kNAYO6875FxzqqlsQBxA==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.13.3.tgz",
+      "integrity": "sha512-BjMhPuT7Us1+YIo31exPRwomPiL+jrZZS5UUAwlEW2XGHDceEotzRM94LwxeFliCScT4IOokGoxixm19qRuzWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.0",
-        "@parcel/utils": "2.13.0",
+        "@parcel/plugin": "2.13.3",
+        "@parcel/utils": "2.13.3",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5372,9 +5389,9 @@
       }
     },
     "node_modules/@parcel/rust": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.13.0.tgz",
-      "integrity": "sha512-7wPx5fma2imcIpwoBHxkt4yMDLYbnxQ1utswXaDj59iDu3mJkHU9/WyZWD2KzZdrADAdF8ulR1fg1woBYQ+nwA==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.13.3.tgz",
+      "integrity": "sha512-dLq85xDAtzr3P5200cvxk+8WXSWauYbxuev9LCPdwfhlaWo/JEj6cu9seVdWlkagjGwkoV1kXC+GGntgUXOLAQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5399,16 +5416,16 @@
       }
     },
     "node_modules/@parcel/transformer-babel": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.13.0.tgz",
-      "integrity": "sha512-hAZFlZoX/RWbMWezk0/2hyFFmM+D0V7KM31NuNZhuCmgeM54e5QeB64qRUFEXFCN0z2XZR2fdxcYNv3dAb17Ww==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.13.3.tgz",
+      "integrity": "sha512-ikzK9f5WTFrdQsPitQgjCPH6HmVU8AQPRemIJ2BndYhtodn5PQut5cnSvTrqax8RjYvheEKCQk/Zb/uR7qgS3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.0",
-        "@parcel/plugin": "2.13.0",
+        "@parcel/diagnostic": "2.13.3",
+        "@parcel/plugin": "2.13.3",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.13.0",
+        "@parcel/utils": "2.13.3",
         "browserslist": "^4.6.6",
         "json5": "^2.2.0",
         "nullthrows": "^1.1.1",
@@ -5416,7 +5433,7 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5424,23 +5441,23 @@
       }
     },
     "node_modules/@parcel/transformer-css": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.13.0.tgz",
-      "integrity": "sha512-zxQ5mYFonnv5LR+7CQNH0KxuO+Lao/mtkwRSS+KqsgM/h3liVOumZ406jgag08f22gwXxndQDCE+khys/ODMIA==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.13.3.tgz",
+      "integrity": "sha512-zbrNURGph6JeVADbGydyZ7lcu/izj41kDxQ9xw4RPRW/3rofQiTU0OTREi+uBWiMENQySXVivEdzHA9cA+aLAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.0",
-        "@parcel/plugin": "2.13.0",
+        "@parcel/diagnostic": "2.13.3",
+        "@parcel/plugin": "2.13.3",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.13.0",
+        "@parcel/utils": "2.13.3",
         "browserslist": "^4.6.6",
         "lightningcss": "^1.22.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5448,15 +5465,15 @@
       }
     },
     "node_modules/@parcel/transformer-html": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.13.0.tgz",
-      "integrity": "sha512-iCgW95Nb+Hvu5y+2owjipuzxGOMzLdw2OHcGAN4iw+lyQtXD1TnovL4kzHxjURk5Jj+or0xRAjACtdHjAz7O8Q==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.13.3.tgz",
+      "integrity": "sha512-Yf74FkL9RCCB4+hxQRVMNQThH9+fZ5w0NLiQPpWUOcgDEEyxTi4FWPQgEBsKl/XK2ehdydbQB9fBgPQLuQxwPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.0",
-        "@parcel/plugin": "2.13.0",
-        "@parcel/rust": "2.13.0",
+        "@parcel/diagnostic": "2.13.3",
+        "@parcel/plugin": "2.13.3",
+        "@parcel/rust": "2.13.3",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.12.1",
@@ -5466,7 +5483,7 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5474,38 +5491,38 @@
       }
     },
     "node_modules/@parcel/transformer-image": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.13.0.tgz",
-      "integrity": "sha512-wehluaZIB6sMqCDU70d2WQW53ubQ6nlzWIsCKoXQxDVThf4xNPbXaqDwZ4udwKZQ+x3frfmeEZXhv1JcFFN5Yw==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.13.3.tgz",
+      "integrity": "sha512-wL1CXyeFAqbp2wcEq/JD3a/tbAyVIDMTC6laQxlIwnVV7dsENhK1qRuJZuoBdixESeUpFQSmmQvDIhcfT/cUUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.0",
-        "@parcel/utils": "2.13.0",
-        "@parcel/workers": "2.13.0",
+        "@parcel/plugin": "2.13.3",
+        "@parcel/utils": "2.13.3",
+        "@parcel/workers": "2.13.3",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.0"
+        "@parcel/core": "^2.13.3"
       }
     },
     "node_modules/@parcel/transformer-js": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.13.0.tgz",
-      "integrity": "sha512-vFSLXhdAQ1G4QqdXPE3bu2Yxh047HeqsxoQpbUNqPzLY/IR8P+ZTG4lUVVE5sGGfck2FfHksJP8uTq6RII4cnw==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.13.3.tgz",
+      "integrity": "sha512-KqfNGn1IHzDoN2aPqt4nDksgb50Xzcny777C7A7hjlQ3cmkjyJrixYjzzsPaPSGJ+kJpknh3KE8unkQ9mhFvRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.0",
-        "@parcel/plugin": "2.13.0",
-        "@parcel/rust": "2.13.0",
+        "@parcel/diagnostic": "2.13.3",
+        "@parcel/plugin": "2.13.3",
+        "@parcel/rust": "2.13.3",
         "@parcel/source-map": "^2.1.1",
-        "@parcel/utils": "2.13.0",
-        "@parcel/workers": "2.13.0",
+        "@parcel/utils": "2.13.3",
+        "@parcel/workers": "2.13.3",
         "@swc/helpers": "^0.5.0",
         "browserslist": "^4.6.6",
         "nullthrows": "^1.1.1",
@@ -5514,29 +5531,29 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.0"
+        "@parcel/core": "^2.13.3"
       }
     },
     "node_modules/@parcel/transformer-json": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.13.0.tgz",
-      "integrity": "sha512-aNmOZcX8oMHrgP4BlqShAoXleTTIstdM2Cflf4d8gUxm4G0GgfYvXRlypxg4twbEtbEHyqrb3qI6wEzIz6U9ZQ==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.13.3.tgz",
+      "integrity": "sha512-rrq0ab6J0w9ePtsxi0kAvpCmrUYXXAx1Z5PATZakv89rSYbHBKEdXxyCoKFui/UPVCUEGVs5r0iOFepdHpIyeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.0",
+        "@parcel/plugin": "2.13.3",
         "json5": "^2.2.0"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5544,16 +5561,16 @@
       }
     },
     "node_modules/@parcel/transformer-postcss": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.13.0.tgz",
-      "integrity": "sha512-04W4QSEqqY36wqpDB9zw847C5LKuQ2pOAO/AseLc7pdvt7W8Pq7GYFTCUUhlo0Lravvw5Z7mMJq043Z05IoCDg==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.13.3.tgz",
+      "integrity": "sha512-AIiWpU0QSFBrPcYIqAnhqB8RGE6yHFznnxztfg1t2zMSOnK3xoU6xqYKv8H/MduShGGrC3qVOeDfM8MUwzL3cw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.0",
-        "@parcel/plugin": "2.13.0",
-        "@parcel/rust": "2.13.0",
-        "@parcel/utils": "2.13.0",
+        "@parcel/diagnostic": "2.13.3",
+        "@parcel/plugin": "2.13.3",
+        "@parcel/rust": "2.13.3",
+        "@parcel/utils": "2.13.3",
         "clone": "^2.1.1",
         "nullthrows": "^1.1.1",
         "postcss-value-parser": "^4.2.0",
@@ -5561,7 +5578,7 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5569,14 +5586,14 @@
       }
     },
     "node_modules/@parcel/transformer-posthtml": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.13.0.tgz",
-      "integrity": "sha512-MnfF0a5LMCALxm5h7zgmGnOkSC/o9J9l6QwddzX1om3MSsCwRWmvEewuASSftyIy80Opx0J8bBPVJbkCCAWqLQ==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.13.3.tgz",
+      "integrity": "sha512-5GSLyccpHASwFAu3uJ83gDIBSvfsGdVmhJvy0Vxe+K1Fklk2ibhvvtUHMhB7mg6SPHC+R9jsNc3ZqY04ZLeGjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.0",
-        "@parcel/utils": "2.13.0",
+        "@parcel/plugin": "2.13.3",
+        "@parcel/utils": "2.13.3",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.12.1",
@@ -5585,7 +5602,7 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5593,17 +5610,17 @@
       }
     },
     "node_modules/@parcel/transformer-raw": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.13.0.tgz",
-      "integrity": "sha512-9gvh3ozDOXOjpufTrEcqmzKisjTFeXA+GO9pochiVdjVB5Sg0FBxFFX9dkcXmC0dFcHchh7/d4unbUUQuCjM8Q==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.13.3.tgz",
+      "integrity": "sha512-BFsAbdQF0l8/Pdb7dSLJeYcd8jgwvAUbHgMink2MNXJuRUvDl19Gns8jVokU+uraFHulJMBj40+K/RTd33in4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.0"
+        "@parcel/plugin": "2.13.3"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5611,19 +5628,19 @@
       }
     },
     "node_modules/@parcel/transformer-react-refresh-wrap": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.13.0.tgz",
-      "integrity": "sha512-AHbCYewzMmIH8ajFvequTtCEST9oHIGHTzYfIss7TMjvAvSrgUs4ESQ9qyNV1Y0A6Nrj5nOe1Oax4bCsBMDWCw==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.13.3.tgz",
+      "integrity": "sha512-mOof4cRyxsZRdg8kkWaFtaX98mHpxUhcGPU+nF9RQVa9q737ItxrorsPNR9hpZAyE2TtFNflNW7RoYsgvlLw8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/plugin": "2.13.0",
-        "@parcel/utils": "2.13.0",
+        "@parcel/plugin": "2.13.3",
+        "@parcel/utils": "2.13.3",
         "react-refresh": ">=0.9 <=0.14"
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5631,15 +5648,15 @@
       }
     },
     "node_modules/@parcel/transformer-svg": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.13.0.tgz",
-      "integrity": "sha512-9lV9ab6TBBs1GQhNcgs9IwpdqvWnfOeZiORqGH7aSpiAaTy9w9Nm+1hSycK5Fz4EZ9wavvdcHftf0LGyymK2MQ==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.13.3.tgz",
+      "integrity": "sha512-9jm7ZF4KHIrGLWlw/SFUz5KKJ20nxHvjFAmzde34R9Wu+F1BOjLZxae7w4ZRwvIc+UVOUcBBQFmhSVwVDZg6Dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.0",
-        "@parcel/plugin": "2.13.0",
-        "@parcel/rust": "2.13.0",
+        "@parcel/diagnostic": "2.13.3",
+        "@parcel/plugin": "2.13.3",
+        "@parcel/rust": "2.13.3",
         "nullthrows": "^1.1.1",
         "posthtml": "^0.16.5",
         "posthtml-parser": "^0.12.1",
@@ -5648,7 +5665,7 @@
       },
       "engines": {
         "node": ">= 16.0.0",
-        "parcel": "^2.13.0"
+        "parcel": "^2.13.3"
       },
       "funding": {
         "type": "opencollective",
@@ -5656,41 +5673,41 @@
       }
     },
     "node_modules/@parcel/types": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.13.0.tgz",
-      "integrity": "sha512-o9Oe43ZIe5rwY/vqE70yZxSPfkNAIoXdLTnqYX+bIDchqWqY6xSSeNdhkwuT5VNKAh5F8T1UJput7rgE6Znx/w==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.13.3.tgz",
+      "integrity": "sha512-+RpFHxx8fy8/dpuehHUw/ja9PRExC3wJoIlIIF42E7SLu2SvlTHtKm6EfICZzxCXNEBzjoDbamCRcN0nmTPlhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/types-internal": "2.13.0",
-        "@parcel/workers": "2.13.0"
+        "@parcel/types-internal": "2.13.3",
+        "@parcel/workers": "2.13.3"
       }
     },
     "node_modules/@parcel/types-internal": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.13.0.tgz",
-      "integrity": "sha512-yhIbaH+VXQB7Leifsnwifr80R6q2Yqeo+xN4KcPGuGH94iX7LrxJ3V0iwUMIg5nGmh5hmNbq0MEYFFxqVuZ8wQ==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/types-internal/-/types-internal-2.13.3.tgz",
+      "integrity": "sha512-Lhx0n+9RCp+Ipktf/I+CLm3zE9Iq9NtDd8b2Vr5lVWyoT8AbzBKIHIpTbhLS4kjZ80L3I6o93OYjqAaIjsqoZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.0",
-        "@parcel/feature-flags": "2.13.0",
+        "@parcel/diagnostic": "2.13.3",
+        "@parcel/feature-flags": "2.13.3",
         "@parcel/source-map": "^2.1.1",
         "utility-types": "^3.10.0"
       }
     },
     "node_modules/@parcel/utils": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.13.0.tgz",
-      "integrity": "sha512-tLHtce8s2gNFHC9kS5VkNrf6YX9ZjVigk/+ZeWpsde8lBpCaY8OHLubJMXSAdk6q26RDn8tCrdMkndlfautDIw==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.13.3.tgz",
+      "integrity": "sha512-yxY9xw2wOUlJaScOXYZmMGoZ4Ck4Kqj+p6Koe5kLkkWM1j98Q0Dj2tf/mNvZi4yrdnlm+dclCwNRnuE8Q9D+pw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/codeframe": "2.13.0",
-        "@parcel/diagnostic": "2.13.0",
-        "@parcel/logger": "2.13.0",
-        "@parcel/markdown-ansi": "2.13.0",
-        "@parcel/rust": "2.13.0",
+        "@parcel/codeframe": "2.13.3",
+        "@parcel/diagnostic": "2.13.3",
+        "@parcel/logger": "2.13.3",
+        "@parcel/markdown-ansi": "2.13.3",
+        "@parcel/rust": "2.13.3",
         "@parcel/source-map": "^2.1.1",
         "chalk": "^4.1.2",
         "nullthrows": "^1.1.1"
@@ -6013,17 +6030,17 @@
       }
     },
     "node_modules/@parcel/workers": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.13.0.tgz",
-      "integrity": "sha512-E9LryfGSog45j/ZSMyGSQVuuBWen2P0s/SEwIsXIYQFP/MGY9tL4ZUwVyfThHOI0kx8d8PfdNaSHBOZEIRrXvQ==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.13.3.tgz",
+      "integrity": "sha512-oAHmdniWTRwwwsKbcF4t3VjOtKN+/W17Wj5laiYB+HLkfsjGTfIQPj3sdXmrlBAGpI4omIcvR70PHHXnfdTfwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/diagnostic": "2.13.0",
-        "@parcel/logger": "2.13.0",
-        "@parcel/profiler": "2.13.0",
-        "@parcel/types-internal": "2.13.0",
-        "@parcel/utils": "2.13.0",
+        "@parcel/diagnostic": "2.13.3",
+        "@parcel/logger": "2.13.3",
+        "@parcel/profiler": "2.13.3",
+        "@parcel/types-internal": "2.13.3",
+        "@parcel/utils": "2.13.3",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -6034,7 +6051,7 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.13.0"
+        "@parcel/core": "^2.13.3"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -6444,15 +6461,15 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-dYyEkO6mRYtZFpnOsnYzv9rY69fHAHoawYOjGOEcxk9WYtaJhowMdP/w6NcOKnz2G7GlZaenjkzkMa6ZeQeMsg==",
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.10.7.tgz",
+      "integrity": "sha512-py91kjI1jV5D5W/Q+PurBdGsdU5TFbrzamP7zSCqLdMcHkKi3rQEM5jkQcZr0MXXSJTaayLxS3MWYTBIkzPDrg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.15"
+        "@swc/types": "^0.1.17"
       },
       "engines": {
         "node": ">=10"
@@ -6462,16 +6479,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.9.2",
-        "@swc/core-darwin-x64": "1.9.2",
-        "@swc/core-linux-arm-gnueabihf": "1.9.2",
-        "@swc/core-linux-arm64-gnu": "1.9.2",
-        "@swc/core-linux-arm64-musl": "1.9.2",
-        "@swc/core-linux-x64-gnu": "1.9.2",
-        "@swc/core-linux-x64-musl": "1.9.2",
-        "@swc/core-win32-arm64-msvc": "1.9.2",
-        "@swc/core-win32-ia32-msvc": "1.9.2",
-        "@swc/core-win32-x64-msvc": "1.9.2"
+        "@swc/core-darwin-arm64": "1.10.7",
+        "@swc/core-darwin-x64": "1.10.7",
+        "@swc/core-linux-arm-gnueabihf": "1.10.7",
+        "@swc/core-linux-arm64-gnu": "1.10.7",
+        "@swc/core-linux-arm64-musl": "1.10.7",
+        "@swc/core-linux-x64-gnu": "1.10.7",
+        "@swc/core-linux-x64-musl": "1.10.7",
+        "@swc/core-win32-arm64-msvc": "1.10.7",
+        "@swc/core-win32-ia32-msvc": "1.10.7",
+        "@swc/core-win32-x64-msvc": "1.10.7"
       },
       "peerDependencies": {
         "@swc/helpers": "*"
@@ -6483,9 +6500,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.9.2.tgz",
-      "integrity": "sha512-nETmsCoY29krTF2PtspEgicb3tqw7Ci5sInTI03EU5zpqYbPjoPH99BVTjj0OsF53jP5MxwnLI5Hm21lUn1d6A==",
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.10.7.tgz",
+      "integrity": "sha512-SI0OFg987P6hcyT0Dbng3YRISPS9uhLX1dzW4qRrfqQdb0i75lPJ2YWe9CN47HBazrIA5COuTzrD2Dc0TcVsSQ==",
       "cpu": [
         "arm64"
       ],
@@ -6500,9 +6517,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.9.2.tgz",
-      "integrity": "sha512-9gD+bwBz8ZByjP6nZTXe/hzd0tySIAjpDHgkFiUrc+5zGF+rdTwhcNrzxNHJmy6mw+PW38jqII4uspFHUqqxuQ==",
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.10.7.tgz",
+      "integrity": "sha512-RFIAmWVicD/l3RzxgHW0R/G1ya/6nyMspE2cAeDcTbjHi0I5qgdhBWd6ieXOaqwEwiCd0Mot1g2VZrLGoBLsjQ==",
       "cpu": [
         "x64"
       ],
@@ -6517,9 +6534,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.9.2.tgz",
-      "integrity": "sha512-kYq8ief1Qrn+WmsTWAYo4r+Coul4dXN6cLFjiPZ29Cv5pyU+GFvSPAB4bEdMzwy99rCR0u2P10UExaeCjurjvg==",
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.10.7.tgz",
+      "integrity": "sha512-QP8vz7yELWfop5mM5foN6KkLylVO7ZUgWSF2cA0owwIaziactB2hCPZY5QU690coJouk9KmdFsPWDnaCFUP8tg==",
       "cpu": [
         "arm"
       ],
@@ -6534,9 +6551,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.9.2.tgz",
-      "integrity": "sha512-n0W4XiXlmEIVqxt+rD3ZpkogsEWUk1jJ+i5bQNgB+1JuWh0fBE8c/blDgTQXa0GB5lTPVDZQussgdNOCnAZwiA==",
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.10.7.tgz",
+      "integrity": "sha512-NgUDBGQcOeLNR+EOpmUvSDIP/F7i/OVOKxst4wOvT5FTxhnkWrW+StJGKj+DcUVSK5eWOYboSXr1y+Hlywwokw==",
       "cpu": [
         "arm64"
       ],
@@ -6551,9 +6568,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.9.2.tgz",
-      "integrity": "sha512-8xzrOmsyCC1zrx2Wzx/h8dVsdewO1oMCwBTLc1gSJ/YllZYTb04pNm6NsVbzUX2tKddJVRgSJXV10j/NECLwpA==",
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.10.7.tgz",
+      "integrity": "sha512-gp5Un3EbeSThBIh6oac5ZArV/CsSmTKj5jNuuUAuEsML3VF9vqPO+25VuxCvsRf/z3py+xOWRaN2HY/rjMeZog==",
       "cpu": [
         "arm64"
       ],
@@ -6568,9 +6585,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.9.2.tgz",
-      "integrity": "sha512-kZrNz/PjRQKcchWF6W292jk3K44EoVu1ad5w+zbS4jekIAxsM8WwQ1kd+yjUlN9jFcF8XBat5NKIs9WphJCVXg==",
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.10.7.tgz",
+      "integrity": "sha512-k/OxLLMl/edYqbZyUNg6/bqEHTXJT15l9WGqsl/2QaIGwWGvles8YjruQYQ9d4h/thSXLT9gd8bExU2D0N+bUA==",
       "cpu": [
         "x64"
       ],
@@ -6585,9 +6602,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.9.2.tgz",
-      "integrity": "sha512-TTIpR4rjMkhX1lnFR+PSXpaL83TrQzp9znRdp2TzYrODlUd/R20zOwSo9vFLCyH6ZoD47bccY7QeGZDYT3nlRg==",
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.10.7.tgz",
+      "integrity": "sha512-XeDoURdWt/ybYmXLCEE8aSiTOzEn0o3Dx5l9hgt0IZEmTts7HgHHVeRgzGXbR4yDo0MfRuX5nE1dYpTmCz0uyA==",
       "cpu": [
         "x64"
       ],
@@ -6602,9 +6619,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.9.2.tgz",
-      "integrity": "sha512-+Eg2d4icItKC0PMjZxH7cSYFLWk0aIp94LNmOw6tPq0e69ax6oh10upeq0D1fjWsKLmOJAWEvnXlayZcijEXDw==",
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.10.7.tgz",
+      "integrity": "sha512-nYAbi/uLS+CU0wFtBx8TquJw2uIMKBnl04LBmiVoFrsIhqSl+0MklaA9FVMGA35NcxSJfcm92Prl2W2LfSnTqQ==",
       "cpu": [
         "arm64"
       ],
@@ -6619,9 +6636,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.9.2.tgz",
-      "integrity": "sha512-nLWBi4vZDdM/LkiQmPCakof8Dh1/t5EM7eudue04V1lIcqx9YHVRS3KMwEaCoHLGg0c312Wm4YgrWQd9vwZ5zQ==",
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.10.7.tgz",
+      "integrity": "sha512-+aGAbsDsIxeLxw0IzyQLtvtAcI1ctlXVvVcXZMNXIXtTURM876yNrufRo4ngoXB3jnb1MLjIIjgXfFs/eZTUSw==",
       "cpu": [
         "ia32"
       ],
@@ -6636,9 +6653,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.9.2.tgz",
-      "integrity": "sha512-ik/k+JjRJBFkXARukdU82tSVx0CbExFQoQ78qTO682esbYXzjdB5eLVkoUbwen299pnfr88Kn4kyIqFPTje8Xw==",
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.10.7.tgz",
+      "integrity": "sha512-TBf4clpDBjF/UUnkKrT0/th76/zwvudk5wwobiTFqDywMApHip5O0VpBgZ+4raY2TM8k5+ujoy7bfHb22zu17Q==",
       "cpu": [
         "x64"
       ],
@@ -6670,9 +6687,9 @@
       }
     },
     "node_modules/@swc/types": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.15.tgz",
-      "integrity": "sha512-XKaZ+dzDIQ9Ot9o89oJQ/aluI17+VvUnIpYJTcZtvv1iYX6MzHh3Ik2CSR7MdPKpPwfZXHBeCingb2b4PoDVdw==",
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.17.tgz",
+      "integrity": "sha512-V5gRru+aD8YVyCOMAjMpWR1Ui577DD5KSJsHP8RAxopAH22jFz6GZd/qxqjO6MJHQhcsjvjOFXyDhyLQUnMveQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -8579,6 +8596,27 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -8762,6 +8800,31 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -12803,6 +12866,27 @@
         "node": ">=4"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -14772,9 +14856,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.28.1.tgz",
-      "integrity": "sha512-KRDkHlLlNj3DWh79CDt93fPlRJh2W1AuHV0ZSZAMMuN7lqlsZTV5842idfS1urWG8q9tc17velp1gCXhY7sLnQ==",
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.29.1.tgz",
+      "integrity": "sha512-FmGoeD4S05ewj+AkhTY+D+myDvXI6eL27FjHIjoyUkO/uw7WZD1fBVs0QxeYWa7E17CUHJaYX/RUGISCtcrG4Q==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -14788,22 +14872,22 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.28.1",
-        "lightningcss-darwin-x64": "1.28.1",
-        "lightningcss-freebsd-x64": "1.28.1",
-        "lightningcss-linux-arm-gnueabihf": "1.28.1",
-        "lightningcss-linux-arm64-gnu": "1.28.1",
-        "lightningcss-linux-arm64-musl": "1.28.1",
-        "lightningcss-linux-x64-gnu": "1.28.1",
-        "lightningcss-linux-x64-musl": "1.28.1",
-        "lightningcss-win32-arm64-msvc": "1.28.1",
-        "lightningcss-win32-x64-msvc": "1.28.1"
+        "lightningcss-darwin-arm64": "1.29.1",
+        "lightningcss-darwin-x64": "1.29.1",
+        "lightningcss-freebsd-x64": "1.29.1",
+        "lightningcss-linux-arm-gnueabihf": "1.29.1",
+        "lightningcss-linux-arm64-gnu": "1.29.1",
+        "lightningcss-linux-arm64-musl": "1.29.1",
+        "lightningcss-linux-x64-gnu": "1.29.1",
+        "lightningcss-linux-x64-musl": "1.29.1",
+        "lightningcss-win32-arm64-msvc": "1.29.1",
+        "lightningcss-win32-x64-msvc": "1.29.1"
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.28.1.tgz",
-      "integrity": "sha512-VG3vvzM0m/rguCdm76DdobNeNJnHK+jWcdkNLFWHLh9YCotRvbRIt45JxwcHlIF8TDqWStVLTdghq5NaigVCBQ==",
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.29.1.tgz",
+      "integrity": "sha512-HtR5XJ5A0lvCqYAoSv2QdZZyoHNttBpa5EP9aNuzBQeKGfbyH5+UipLWvVzpP4Uml5ej4BYs5I9Lco9u1fECqw==",
       "cpu": [
         "arm64"
       ],
@@ -14822,9 +14906,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.28.1.tgz",
-      "integrity": "sha512-O7ORdislvKfMohFl4Iq7fxKqdJOuuxArcglVI3amuFO5DJ0wfV3Gxgi1JRo49slfr7OVzJQEHLG4muTWYM5cTQ==",
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.29.1.tgz",
+      "integrity": "sha512-k33G9IzKUpHy/J/3+9MCO4e+PzaFblsgBjSGlpAaFikeBFm8B/CkO3cKU9oI4g+fjS2KlkLM/Bza9K/aw8wsNA==",
       "cpu": [
         "x64"
       ],
@@ -14843,9 +14927,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.28.1.tgz",
-      "integrity": "sha512-b7sF89B31kYYijxVcFO7l5u6UNA862YstNu+3YbLl/IQKzveL4a5cwR5cdpG+OOhErg/c2u9WCmzZoX2I5GBvw==",
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.29.1.tgz",
+      "integrity": "sha512-0SUW22fv/8kln2LnIdOCmSuXnxgxVC276W5KLTwoehiO0hxkacBxjHOL5EtHD8BAXg2BvuhsJPmVMasvby3LiQ==",
       "cpu": [
         "x64"
       ],
@@ -14864,9 +14948,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.28.1.tgz",
-      "integrity": "sha512-p61kXwvhUDLLzkWHjzSFfUBW/F0iy3jr3CWi3k8SKULtJEsJXTI9DqRm9EixxMSe2AMBQBt4auTYiQL4B1N51A==",
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.29.1.tgz",
+      "integrity": "sha512-sD32pFvlR0kDlqsOZmYqH/68SqUMPNj+0pucGxToXZi4XZgZmqeX/NkxNKCPsswAXU3UeYgDSpGhu05eAufjDg==",
       "cpu": [
         "arm"
       ],
@@ -14885,9 +14969,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.28.1.tgz",
-      "integrity": "sha512-iO+fN9hOMmzfwqcG2/BgUtMKD48H2JO/SXU44fyIwpY2veb65QF5xiRrQ9l1FwIxbGK3231KBYCtAqv+xf+NsQ==",
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.29.1.tgz",
+      "integrity": "sha512-0+vClRIZ6mmJl/dxGuRsE197o1HDEeeRk6nzycSy2GofC2JsY4ifCRnvUWf/CUBQmlrvMzt6SMQNMSEu22csWQ==",
       "cpu": [
         "arm64"
       ],
@@ -14906,9 +14990,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.28.1.tgz",
-      "integrity": "sha512-dnMHeXEmCUzHHZjaDpQBYuBKcN9nPC3nPFKl70bcj5Bkn5EmkcgEqm5p035LKOgvAwk1XwLpQCML6pXmCwz0NQ==",
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.29.1.tgz",
+      "integrity": "sha512-UKMFrG4rL/uHNgelBsDwJcBqVpzNJbzsKkbI3Ja5fg00sgQnHw/VrzUTEc4jhZ+AN2BvQYz/tkHu4vt1kLuJyw==",
       "cpu": [
         "arm64"
       ],
@@ -14927,9 +15011,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.28.1.tgz",
-      "integrity": "sha512-7vWDISaMUn+oo2TwRdf2hl/BLdPxvywv9JKEqNZB/0K7bXwV4XE9wN/C2sAp1gGuh6QBA8lpjF4JIPt3HNlCHA==",
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.29.1.tgz",
+      "integrity": "sha512-u1S+xdODy/eEtjADqirA774y3jLcm8RPtYztwReEXoZKdzgsHYPl0s5V52Tst+GKzqjebkULT86XMSxejzfISw==",
       "cpu": [
         "x64"
       ],
@@ -14948,9 +15032,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.28.1.tgz",
-      "integrity": "sha512-IHCu9tVGP+x5BCpA2rF3D04DBokcBza/a8AuHQU+1AiMKubuMegPwcL7RatBgK4ztFHeYnnD5NdhwhRfYMAtNA==",
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.29.1.tgz",
+      "integrity": "sha512-L0Tx0DtaNUTzXv0lbGCLB/c/qEADanHbu4QdcNOXLIe1i8i22rZRpbT3gpWYsCh9aSL9zFujY/WmEXIatWvXbw==",
       "cpu": [
         "x64"
       ],
@@ -14969,9 +15053,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.28.1.tgz",
-      "integrity": "sha512-Erm72kHmMg/3h350PTseskz+eEGBM17Fuu79WW2Qqt0BfWSF1jHHc12lkJCWMYl5jcBHPs5yZdgNHtJ7IJS3Uw==",
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.29.1.tgz",
+      "integrity": "sha512-QoOVnkIEFfbW4xPi+dpdft/zAKmgLgsRHfJalEPYuJDOWf7cLQzYg0DEh8/sn737FaeMJxHZRc1oBreiwZCjog==",
       "cpu": [
         "arm64"
       ],
@@ -14990,9 +15074,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.28.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.28.1.tgz",
-      "integrity": "sha512-ZPQtvx+uQBzrSdHH8p4H3M9Alue+x369TPZAA3b4K3d92FPhpZCuBG04+HQzspam9sVeID9mI6f3VRAs2ezaEA==",
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.29.1.tgz",
+      "integrity": "sha512-NygcbThNBe4JElP+olyTI/doBNGJvLs3bFCRPdvuCcxZCcCZ71B858IHpdm7L1btZex0FvCmM17FK98Y9MRy1Q==",
       "cpu": [
         "x64"
       ],
@@ -16085,24 +16169,24 @@
       }
     },
     "node_modules/parcel": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.13.0.tgz",
-      "integrity": "sha512-3IsoqffuH7H/RLrvz3nS6UezJb+iE/L0xTukDTkZNOLUhwI3EW75S6FLCPs+UGTlzqvoCgf7IkyTSRFln9C4rA==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.13.3.tgz",
+      "integrity": "sha512-8GrC8C7J8mwRpAlk7EJ7lwdFTbCN+dcXH2gy5AsEs9pLfzo9wvxOTx6W0fzSlvCOvZOita+8GdfYlGfEt0tRgA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@parcel/config-default": "2.13.0",
-        "@parcel/core": "2.13.0",
-        "@parcel/diagnostic": "2.13.0",
-        "@parcel/events": "2.13.0",
-        "@parcel/feature-flags": "2.13.0",
-        "@parcel/fs": "2.13.0",
-        "@parcel/logger": "2.13.0",
-        "@parcel/package-manager": "2.13.0",
-        "@parcel/reporter-cli": "2.13.0",
-        "@parcel/reporter-dev-server": "2.13.0",
-        "@parcel/reporter-tracer": "2.13.0",
-        "@parcel/utils": "2.13.0",
+        "@parcel/config-default": "2.13.3",
+        "@parcel/core": "2.13.3",
+        "@parcel/diagnostic": "2.13.3",
+        "@parcel/events": "2.13.3",
+        "@parcel/feature-flags": "2.13.3",
+        "@parcel/fs": "2.13.3",
+        "@parcel/logger": "2.13.3",
+        "@parcel/package-manager": "2.13.3",
+        "@parcel/reporter-cli": "2.13.3",
+        "@parcel/reporter-dev-server": "2.13.3",
+        "@parcel/reporter-tracer": "2.13.3",
+        "@parcel/utils": "2.13.3",
         "chalk": "^4.1.2",
         "commander": "^12.1.0",
         "get-port": "^4.2.0"
@@ -17760,9 +17844,9 @@
       }
     },
     "node_modules/posthtml-parser/node_modules/domutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/webview/resource-dependency-graph/package.json
+++ b/webview/resource-dependency-graph/package.json
@@ -47,11 +47,16 @@
   },
   "devDependencies": {
     "@types/styled-components": "^5.1.34",
-    "parcel": "^2.13.0",
-    "process": "^0.11.10"
+    "parcel": "^2.13.3",
+    "process": "^0.11.10",
+    "buffer": "^5.5.0"
   },
   "overrides": {
     "nth-check": ">=2.0.2",
     "postcss": ">=8.4.31"
-  }
+  },
+  "alias": {
+    "process": "process/browser.js",
+    "buffer": "buffer"
+ }
 }


### PR DESCRIPTION
This PR builds the webview applications implicit to make sure that everything is set right.

Process and Buffer are aliases because of this packer issue: https://github.com/parcel-bundler/parcel/issues/7697