### PR TITLE
feat: update embedded humctl and override humanitec user agent to identify the user agent

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,11 @@ jobs:
       - run: npm test
         if: runner.os != 'Linux'
 
+      - if: startsWith(github.ref, 'refs/tags/') && runner.os == 'Linux'
+        name: Inject user agent version
+        run:
+            sed -i "s/VsceVersion = 'unspecified'/VsceVersion = '${{ github.ref_name }}'/g" src/extension.ts
+
       - name: Validate extension is packable
         if: runner.os == 'Linux'
         run: npx vsce package

--- a/scripts/download-humctl.js
+++ b/scripts/download-humctl.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const CLI_VERSION = '0.28.0';
+const CLI_VERSION = '0.36.2';
 
 const fs = require('node:fs/promises');
 const extractZip = require('extract-zip');

--- a/src/adapters/humctl/HumctlAdapter.ts
+++ b/src/adapters/humctl/HumctlAdapter.ts
@@ -15,6 +15,7 @@ import { UnsupportedOperatingSystemError } from '../../errors/UnsupportedOperati
 import path from 'path';
 import { ExtensionContext } from 'vscode';
 import { NoDeploymentsInEnvironmentError } from '../../errors/NoDeploymentsInEnvironmentError';
+import { VsceVersion } from '../../extension';
 
 export class HumctlAdapter implements IHumctlAdapter {
   constructor(
@@ -43,7 +44,7 @@ export class HumctlAdapter implements IHumctlAdapter {
     }
 
     // TODO: upgrade to a later version once https://github.com/humanitec/cli-internal/pull/257/ is merged.
-    let humctlEmbeddedBinaryFilename = `cli_0.28.0_${os}_${arch}`;
+    let humctlEmbeddedBinaryFilename = `cli_0.36.2_${os}_${arch}`;
     if (os === 'win32') {
       humctlEmbeddedBinaryFilename += '.exe';
     }
@@ -135,7 +136,7 @@ export class HumctlAdapter implements IHumctlAdapter {
       HUMANITEC_ENV: env,
       HUMANITEC_OUTPUT: 'json',
       HUMANITEC_CLI_ALPHA_FEATURES: '',
-      HUMANITEC_OVERRIDE_USER_AGENT: 'humanitec-vscode-extension/unspecified',
+      HUMANITEC_OVERRIDE_USER_AGENT: `humanitec-vscode-extension/${VsceVersion}`,
     };
   }
 }

--- a/src/adapters/humctl/HumctlAdapter.ts
+++ b/src/adapters/humctl/HumctlAdapter.ts
@@ -42,6 +42,7 @@ export class HumctlAdapter implements IHumctlAdapter {
       throw new UnsupportedOperatingSystemError(os, arch);
     }
 
+    // TODO: upgrade to a later version once https://github.com/humanitec/cli-internal/pull/257/ is merged.
     let humctlEmbeddedBinaryFilename = `cli_0.28.0_${os}_${arch}`;
     if (os === 'win32') {
       humctlEmbeddedBinaryFilename += '.exe';
@@ -134,6 +135,7 @@ export class HumctlAdapter implements IHumctlAdapter {
       HUMANITEC_ENV: env,
       HUMANITEC_OUTPUT: 'json',
       HUMANITEC_CLI_ALPHA_FEATURES: '',
+      HUMANITEC_OVERRIDE_USER_AGENT: 'humanitec-vscode-extension/unspecified',
     };
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,8 @@ import { ActiveResourcesRepository } from './repos/ActiveResourcesRepository';
 import { DependencyGraphRepository } from './repos/DependencyGraphRepository';
 import { ResourceDefinitionRepository } from './repos/ResourceDefinitionRepository';
 
+export const VsceVersion = 'unspecified';
+
 export const loggerChannel = vscode.window.createOutputChannel('Humanitec');
 
 export async function activate(context: vscode.ExtensionContext) {


### PR DESCRIPTION
This PR contains 3 things:

1. Update embedded humctl version to one that accepts the user agent override string
2. Gather vscode extension version during build process
3. Override app user agent and send user agent header via CLI on api calls

This will allow us to see not only that someone was using Vscode extension but also what version they were using.

Testing shows this working with nginx logs reporting the humanitec user agent including vscode app (unspecified is expected since this is from source not ci).

![image](https://github.com/user-attachments/assets/4ed973cf-aca8-485c-9245-cf0d3c4dc104)
